### PR TITLE
Suggestions for fixing issues #15 Renaming API and #16 Extract Error formatting code from AssertOrder

### DIFF
--- a/src/assertOrder.spec.ts
+++ b/src/assertOrder.spec.ts
@@ -3,40 +3,40 @@ import AssertOrder from './index'
 
 test('different starting index', _t => {
   let a = new AssertOrder(0, 1)
-  a.once(1)
-  a.once(2)
+  a.runOnce(1)
+  a.runOnce(2)
 
   a = new AssertOrder(0, -1)
-  a.once(-1)
-  a.once(0)
-  a.once(1)
+  a.runOnce(-1)
+  a.runOnce(0)
+  a.runOnce(1)
 
   a = new AssertOrder(0, 5)
-  a.once(5)
-  a.once(6)
+  a.runOnce(5)
+  a.runOnce(6)
 })
 
-test('once()', t => {
+test('runOnce()', t => {
   let a = new AssertOrder()
-  a.once(0)
+  a.runOnce(0)
   t.is(a.next, 1)
-  a.once(1)
+  a.runOnce(1)
   t.is(a.next, 2)
-  a.once(2)
+  a.runOnce(2)
   t.is(a.next, 3)
-  a.once(3)
+  a.runOnce(3)
   t.is(a.next, 4)
 
   a = new AssertOrder()
-  t.throws(() => a.once(1), "Expecting 'once(0)', 'step(0)', 'some(0)', 'all(0)', 'multiple(0)', but received 'once(1)'")
+  t.throws(() => a.runOnce(1), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'runOnce(1)'")
 
   a = new AssertOrder()
-  a.once(0)
-  t.throws(() => a.once(2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'once(2)'")
+  a.runOnce(0)
+  t.throws(() => a.runOnce(2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'runOnce(2)'")
 
   a = new AssertOrder()
-  a.once(0)
-  t.throws(() => a.once(0), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'once(0)'")
+  a.runOnce(0)
+  t.throws(() => a.runOnce(0), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'runOnce(0)'")
 })
 
 test('step()', t => {
@@ -47,15 +47,15 @@ test('step()', t => {
   a.step(3)
 
   a = new AssertOrder()
-  t.throws(() => a.step(1), "Expecting 'once(0)', 'step(0)', 'some(0)', 'all(0)', 'multiple(0)', but received 'step(1)'")
+  t.throws(() => a.step(1), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'step(1)'")
 
   a = new AssertOrder()
   a.step(0)
-  t.throws(() => a.step(2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'step(2)'")
+  t.throws(() => a.step(2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'step(2)'")
 
   a = new AssertOrder()
   a.step(0)
-  t.throws(() => a.step(0), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'step(0)'")
+  t.throws(() => a.step(0), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'step(0)'")
 })
 
 test('any()', t => {
@@ -73,90 +73,90 @@ test('any()', t => {
   a.step(5)
 
   a = new AssertOrder()
-  t.throws(() => a.any(1, 2), "Expecting 'once(0)', 'step(0)', 'some(0)', 'all(0)', 'multiple(0)', but received 'any(1,2)'")
+  t.throws(() => a.any(1, 2), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'any(1,2)'")
 
   a = new AssertOrder()
   a.step(0)
-  t.throws(() => a.any(2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'any(2)'")
+  t.throws(() => a.any(2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'any(2)'")
 })
 
-test('some()', t => {
+test('runAtleastOnce()', t => {
   let a = new AssertOrder()
 
   a.step(0)
   t.is(a.next, 1)
-  a.some(1)
+  a.runAtleastOnce(1)
   t.is(a.next, 2)
-  a.some(1)
+  a.runAtleastOnce(1)
   t.is(a.next, 2)
   a.step(2)
   t.is(a.next, 3)
 
   a = new AssertOrder()
 
-  a.some(0)
-  a.some(0)
+  a.runAtleastOnce(0)
+  a.runAtleastOnce(0)
   a.step(1)
-  t.throws(() => a.some(1), "Expecting 'once(2)', 'step(2)', 'some(2)', 'all(2)', 'multiple(2)', but received 'some(1)'")
+  t.throws(() => a.runAtleastOnce(1), "Expecting 'runOnce(2)', 'step(2)', 'runAtleastOnce(2)', 'repeatExactCount(2)', 'multiple(2)', but received 'runAtleastOnce(1)'")
 
   a = new AssertOrder()
-  t.is(a.some(0), 1)
-  t.is(a.some(0), 2)
-  t.is(a.some(1), 1)
-  t.is(a.some(1), 2)
-  t.is(a.some(2), 1)
-  t.is(a.some(2), 2)
+  t.is(a.runAtleastOnce(0), 1)
+  t.is(a.runAtleastOnce(0), 2)
+  t.is(a.runAtleastOnce(1), 1)
+  t.is(a.runAtleastOnce(1), 2)
+  t.is(a.runAtleastOnce(2), 1)
+  t.is(a.runAtleastOnce(2), 2)
 
   a = new AssertOrder()
-  a.some(0)
-  a.some(1)
-  t.throws(() => a.some(0), "Expecting 'once(2)', 'step(2)', 'some(1|2)', 'all(2)', 'multiple(2)', but received 'some(0)'")
+  a.runAtleastOnce(0)
+  a.runAtleastOnce(1)
+  t.throws(() => a.runAtleastOnce(0), "Expecting 'runOnce(2)', 'step(2)', 'runAtleastOnce(1|2)', 'repeatExactCount(2)', 'multiple(2)', but received 'runAtleastOnce(0)'")
 
   a = new AssertOrder()
-  t.throws(() => a.some(1), "Expecting 'once(0)', 'step(0)', 'some(0)', 'all(0)', 'multiple(0)', but received 'some(1)'")
+  t.throws(() => a.runAtleastOnce(1), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'runAtleastOnce(1)'")
 
   a = new AssertOrder()
-  a.some(0)
-  t.throws(() => a.some(2), "Expecting 'once(1)', 'step(1)', 'some(0|1)', 'all(1)', 'multiple(1)', but received 'some(2)'")
+  a.runAtleastOnce(0)
+  t.throws(() => a.runAtleastOnce(2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(0|1)', 'repeatExactCount(1)', 'multiple(1)', but received 'runAtleastOnce(2)'")
 })
 
-test('all()', t => {
+test('repeatExactCount()', t => {
   let a = new AssertOrder()
-  t.is(a.all(0, 2), 1)
+  t.is(a.repeatExactCount(0, 2), 1)
   t.is(a.next, 0)
-  t.is(a.all(0, 2), 2)
+  t.is(a.repeatExactCount(0, 2), 2)
   t.is(a.next, 1)
   a.step(1)
   t.is(a.next, 2)
 
   a = new AssertOrder()
-  t.throws(() => a.all(0, 0), "0 is not a valid 'plan' value.")
-  t.throws(() => a.all(0, -1), "-1 is not a valid 'plan' value.")
+  t.throws(() => a.repeatExactCount(0, 0), "0 is not a valid 'plan' value.")
+  t.throws(() => a.repeatExactCount(0, -1), "-1 is not a valid 'plan' value.")
 
   a = new AssertOrder()
   a.step(0)
-  a.some(1)
-  t.throws(() => a.all(1, 1), "Expecting 'once(2)', 'step(2)', 'some(1|2)', 'all(2)', 'multiple(2)', but received 'all(1)'")
+  a.runAtleastOnce(1)
+  t.throws(() => a.repeatExactCount(1, 1), "Expecting 'runOnce(2)', 'step(2)', 'runAtleastOnce(1|2)', 'repeatExactCount(2)', 'multiple(2)', but received 'repeatExactCount(1)'")
 
   a = new AssertOrder()
   a.step(0)
-  a.all(1, 2)
-  t.throws(() => a.some(1), "Expecting 'all(1)', 'multiple(1)', but received 'some(1)'")
+  a.repeatExactCount(1, 2)
+  t.throws(() => a.runAtleastOnce(1), "Expecting 'repeatExactCount(1)', 'multiple(1)', but received 'runAtleastOnce(1)'")
 
   a = new AssertOrder()
-  a.all(0, 2)
-  a.all(0, 2)
-  t.throws(() => a.all(0, 2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'all(0)'")
+  a.repeatExactCount(0, 2)
+  a.repeatExactCount(0, 2)
+  t.throws(() => a.repeatExactCount(0, 2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'repeatExactCount(0)'")
 
   a = new AssertOrder()
-  a.all(0, 2)
-  t.throws(() => a.all(0, 3), 'The plan count (3) does not match with previous value (2).')
+  a.repeatExactCount(0, 2)
+  t.throws(() => a.repeatExactCount(0, 3), 'The plan count (3) does not match with previous value (2).')
 
   a = new AssertOrder()
-  t.is(a.all(0, 1), 1)
+  t.is(a.repeatExactCount(0, 1), 1)
   a.step(1)
-  t.is(a.all(2, 2), 1)
-  t.is(a.all(2, 2), 2)
+  t.is(a.repeatExactCount(2, 2), 1)
+  t.is(a.repeatExactCount(2, 2), 2)
   a.step(3)
 })
 
@@ -175,18 +175,18 @@ test('multiple()', t => {
 
   a = new AssertOrder()
   a.step(0)
-  a.some(1)
-  t.throws(() => a.multiple(1, 1), "Expecting 'once(2)', 'step(2)', 'some(1|2)', 'all(2)', 'multiple(2)', but received 'multiple(1)'")
+  a.runAtleastOnce(1)
+  t.throws(() => a.multiple(1, 1), "Expecting 'runOnce(2)', 'step(2)', 'runAtleastOnce(1|2)', 'repeatExactCount(2)', 'multiple(2)', but received 'multiple(1)'")
 
   a = new AssertOrder()
   a.step(0)
   a.multiple(1, 2)
-  t.throws(() => a.some(1), "Expecting 'all(1)', 'multiple(1)', but received 'some(1)'")
+  t.throws(() => a.runAtleastOnce(1), "Expecting 'repeatExactCount(1)', 'multiple(1)', but received 'runAtleastOnce(1)'")
 
   a = new AssertOrder()
   a.multiple(0, 2)
   a.multiple(0, 2)
-  t.throws(() => a.multiple(0, 2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'multiple(0)'")
+  t.throws(() => a.multiple(0, 2), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'multiple(0)'")
 
   a = new AssertOrder()
   a.multiple(0, 2)
@@ -212,17 +212,17 @@ test('end()', t => {
   a.end()
 
   a = new AssertOrder(3)
-  a.once(0)
-  t.is(a.some(1), 1)
-  t.is(a.some(1), 2)
-  t.is(a.all(2, 2), 1)
+  a.runOnce(0)
+  t.is(a.runAtleastOnce(1), 1)
+  t.is(a.runAtleastOnce(1), 2)
+  t.is(a.repeatExactCount(2, 2), 1)
   t.throws(() => a.end(), `Planned 3 steps but executed 2 steps`)
-  t.is(a.all(2, 2), 2)
+  t.is(a.repeatExactCount(2, 2), 2)
   a.end()
 
   a = new AssertOrder(1)
   setTimeout(() => {
-    a.once(0)
+    a.runOnce(0)
   }, 10)
   return a.end(50)
 })
@@ -230,7 +230,7 @@ test('end()', t => {
 test(`end() reject`, t => {
   const a = new AssertOrder(2)
   setTimeout(() => {
-    a.once(0)
+    a.runOnce(0)
   }, 50)
   return a.end(1).then(() => t.fail('should fail'), () => t.pass('should fail'))
 })

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,19 +1,19 @@
 export interface Steps {
-  once?: number[]
-  some?: number[]
-  all?: number[]
+  runOnce?: number[]
+  runAtleastOnce?: number[]
+  repeatExactCount?: number[]
 }
 
 export class AssertOrder {
   private static alias = {
-    step: 'once',
-    any: 'once',
-    multiple: 'all'
+    step: 'runOnce',
+    any: 'runOnce',
+    multiple: 'repeatExactCount'
   }
   private static reverseAlias = {
-    once: ['step'],
-    some: [],
-    all: ['multiple']
+    runOnce: ['step'],
+    runAtleastOnce: [],
+    repeatExactCount: ['multiple']
   }
 
   /**
@@ -28,9 +28,9 @@ export class AssertOrder {
   constructor(public plannedSteps?: number, initStep = 0) {
     this.nextStep = initStep
     this.possibleMoves = {
-      once: [initStep],
-      some: [initStep],
-      all: [initStep]
+      runOnce: [initStep],
+      runAtleastOnce: [initStep],
+      repeatExactCount: [initStep]
     }
   }
 
@@ -77,14 +77,14 @@ export class AssertOrder {
   /**
    * Assert the specified step will run once.
    */
-  once(step: number) {
+  runOnce(step: number) {
     // this.validate('once', [step], 1)
-    if (this.isValidStep('once', [step])) {
+    if (this.isValidStep('runOnce', [step])) {
       this.moveNext()
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('once', step))
+      throw new Error(this.getErrorMessage('runOnce', step))
     }
   }
 
@@ -106,13 +106,13 @@ export class AssertOrder {
    * Assert the specified step will be reached at least once.
    * @returns how many times this step has occured.
    */
-  some(step: number) {
-    if (this.isValidStep('some', [step])) {
+  runAtleastOnce(step: number) {
+    if (this.isValidStep('runAtleastOnce', [step])) {
       if (step === this.nextStep) {
         this.moveNext({
-          once: [step + 1],
-          some: [step, step + 1],
-          all: [step + 1]
+          runOnce: [step + 1],
+          runAtleastOnce: [step, step + 1],
+          repeatExactCount: [step + 1]
         })
         this.miniSteps = 0
         this.nextStep++
@@ -121,7 +121,7 @@ export class AssertOrder {
       return ++this.miniSteps
     }
     else {
-      throw new Error(this.getErrorMessage('some', step))
+      throw new Error(this.getErrorMessage('runAtleastOnce', step))
     }
   }
 
@@ -129,14 +129,14 @@ export class AssertOrder {
    * Assert the specified step will be reached x times.
    * @returns how many times this step has occured.
    */
-  all(step: number, plan: number) {
+  repeatExactCount(step: number, plan: number) {
     this.validatePlanned(plan)
 
-    if (this.isValidStep('all', [step], plan)) {
+    if (this.isValidStep('repeatExactCount', [step], plan)) {
       return this.moveAllState(step, plan)
     }
     else {
-      throw new Error(this.getErrorMessage('all', step))
+      throw new Error(this.getErrorMessage('repeatExactCount', step))
     }
   }
 
@@ -169,7 +169,7 @@ export class AssertOrder {
       this.targetMiniSteps = plan
       this.miniSteps = 0
       this.moveNext({
-        all: [step]
+        repeatExactCount: [step]
       })
     }
 
@@ -189,9 +189,9 @@ export class AssertOrder {
     return (!count || this.miniSteps <= count) && step !== undefined
   }
   private moveNext(nextMoves: Steps = {
-    once: [this.nextStep + 1],
-    some: [this.nextStep + 1],
-    all: [this.nextStep + 1]
+    runOnce: [this.nextStep + 1],
+    runAtleastOnce: [this.nextStep + 1],
+    repeatExactCount: [this.nextStep + 1]
   }) {
     this.possibleMoves = nextMoves
   }

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,3 +1,7 @@
+import {FormatError} from './formatError'
+
+var errFormatter = new FormatError();
+
 export interface Steps {
   runOnce?: number[]
   runAtleastOnce?: number[]
@@ -70,7 +74,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('step', step))
+      throw new Error(errFormatter.formatError('step',this.possibleMoves,AssertOrder.reverseAlias,step));
     }
   }
 
@@ -84,7 +88,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('runOnce', step))
+      throw new Error(errFormatter.formatError('runOnce',this.possibleMoves,AssertOrder.reverseAlias,step));
     }
   }
 
@@ -98,7 +102,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('any', ...anySteps))
+      throw new Error(errFormatter.formatError('any',this.possibleMoves,AssertOrder.reverseAlias,...anySteps));
     }
   }
 
@@ -121,7 +125,7 @@ export class AssertOrder {
       return ++this.miniSteps
     }
     else {
-      throw new Error(this.getErrorMessage('runAtleastOnce', step))
+      throw new Error(errFormatter.formatError('runAtleastOnce',this.possibleMoves,AssertOrder.reverseAlias,step));
     }
   }
 
@@ -136,7 +140,7 @@ export class AssertOrder {
       return this.moveAllState(step, plan)
     }
     else {
-      throw new Error(this.getErrorMessage('repeatExactCount', step))
+      throw new Error(errFormatter.formatError('repeatExactCount',this.possibleMoves,AssertOrder.reverseAlias,step));
     }
   }
 
@@ -151,7 +155,7 @@ export class AssertOrder {
       return this.moveAllState(step, plan)
     }
     else {
-      throw new Error(this.getErrorMessage('multiple', step))
+      throw new Error(errFormatter.formatError('multiple',this.possibleMoves,AssertOrder.reverseAlias, step));
     }
   }
 
@@ -194,16 +198,5 @@ export class AssertOrder {
     repeatExactCount: [this.nextStep + 1]
   }) {
     this.possibleMoves = nextMoves
-  }
-
-  private getErrorMessage(calledFn: string, ...calledSteps: number[]) {
-    const should: string[] = []
-    for (let key in this.possibleMoves) {
-      should.push(...([key, ...AssertOrder.reverseAlias[key]].map(name =>
-        `'${name}(${this.possibleMoves[key].join('|')})'`
-      )))
-    }
-
-    return `Expecting ${should.join(', ')}, but received '${calledFn}(${calledSteps.join(',')})'`
   }
 }

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,6 +1,6 @@
 import {FormatError} from './formatError'
 
-var errFormatter = new FormatError();
+let errFormatter = new FormatError();
 
 export interface Steps {
   runOnce?: number[]

--- a/src/formatError.spec.ts
+++ b/src/formatError.spec.ts
@@ -1,0 +1,22 @@
+import test from 'ava'
+import {AssertOrder} from './assertOrder'
+
+test('Testing message for runOnce error case', _t => {
+  let a = new AssertOrder();
+  a.runOnce(1);
+  _t.throws(() => a.runOnce(1), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'runOnce(1)'")
+})
+
+test('Testing message for runAtleastOnce error case', _t => {
+  let a = new AssertOrder();
+  a.runOnce(0);
+  a.runAtleastOnce(3);
+  _t.throws(() => a.runAtleastOnce(3), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'runAtleastOnce(3)'")
+})
+
+test('Testing message for repeatExactCount error case', _t => {
+  let a = new AssertOrder()
+  a.runOnce(0);
+  a.repeatExactCount(3,3);
+  _t.throws(() => a.repeatExactCount(3,3), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'repeatExactCount(3,3)'")
+})

--- a/src/formatError.spec.ts
+++ b/src/formatError.spec.ts
@@ -3,20 +3,17 @@ import {AssertOrder} from './assertOrder'
 
 test('Testing message for runOnce error case', _t => {
   let a = new AssertOrder();
-  a.runOnce(1);
   _t.throws(() => a.runOnce(1), "Expecting 'runOnce(0)', 'step(0)', 'runAtleastOnce(0)', 'repeatExactCount(0)', 'multiple(0)', but received 'runOnce(1)'")
 })
 
 test('Testing message for runAtleastOnce error case', _t => {
   let a = new AssertOrder();
   a.runOnce(0);
-  a.runAtleastOnce(3);
   _t.throws(() => a.runAtleastOnce(3), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'runAtleastOnce(3)'")
 })
 
 test('Testing message for repeatExactCount error case', _t => {
   let a = new AssertOrder()
   a.runOnce(0);
-  a.repeatExactCount(3,3);
-  _t.throws(() => a.repeatExactCount(3,3), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'repeatExactCount(3,3)'")
+  _t.throws(() => a.repeatExactCount(3,3), "Expecting 'runOnce(1)', 'step(1)', 'runAtleastOnce(1)', 'repeatExactCount(1)', 'multiple(1)', but received 'repeatExactCount(3)'")
 })

--- a/src/formatError.ts
+++ b/src/formatError.ts
@@ -1,0 +1,11 @@
+import {Steps} from './assertOrder'
+
+export class FormatError{
+  public formatError(calledFnName: string, possibleMoves:Steps, reverseAlias: {},...calledSteps: number[]) {
+    const expectedFunction: string[] = [];
+    for (let key in possibleMoves) {
+      expectedFunction.push(...([key, ...reverseAlias[key]].map(name =>`'${name}(${possibleMoves[key].join('|')})'`)));
+    }
+    return `Expecting ${expectedFunction.join(', ')}, but received '${calledFnName}(${calledSteps.join(',')})'`;
+  }
+}

--- a/src/formatError.ts
+++ b/src/formatError.ts
@@ -1,10 +1,10 @@
 import {Steps} from './assertOrder'
 
-export class FormatError{
-  public formatError(calledFnName: string, possibleMoves:Steps, reverseAlias: {},...calledSteps: number[]) {
+export class FormatError {
+  public formatError(calledFnName: string, possibleMoves: Steps, reverseAlias: {},...calledSteps: number[]) {
     const expectedFunction: string[] = [];
     for (let key in possibleMoves) {
-      expectedFunction.push(...([key, ...reverseAlias[key]].map(name =>`'${name}(${possibleMoves[key].join('|')})'`)));
+      expectedFunction.push(...([key, ...reverseAlias[key]].map(name => `'${name}(${possibleMoves[key].join('|')})'`)));
     }
     return `Expecting ${expectedFunction.join(', ')}, but received '${calledFnName}(${calledSteps.join(',')})'`;
   }


### PR DESCRIPTION
Hello Homa,
   These are suggested fixes for 

1. Issue #16 Renaming API .Here's a snapshot of the name changes
   once() -> runOnce()
   some() -> runAtleastOnce()
   all() -> repeatExactCount()

2. Issue #15 Extract Error formating code from AssertOrder. 

Thanks,
Ashwini