### PR TITLE
[#10] add asynchronous tests

### DIFF
--- a/src/assertOrder.spec.ts
+++ b/src/assertOrder.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import utils from './testUtils'
+import * as utils from './testUtils'
 import AssertOrder from './index'
 
 test('different starting index', _t => {

--- a/src/assertOrder.spec.ts
+++ b/src/assertOrder.spec.ts
@@ -1,7 +1,9 @@
 import test from 'ava'
+import utils from './testUtils'
 import AssertOrder from './index'
 
-test('different starting index', _t => {
+
+test('different starting index', t => {
   let a = new AssertOrder(0, 1)
   a.once(1)
   a.once(2)
@@ -37,6 +39,29 @@ test('once()', t => {
   a = new AssertOrder()
   a.once(0)
   t.throws(() => a.once(0), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'once(0)'")
+})
+
+test('once() async', async t => {
+  let a = new AssertOrder()
+  await utils.onceAsync(a, 0)
+  t.is(a.next, 1)
+  await utils.onceAsync(a, 1)
+  t.is(a.next, 2)
+  await utils.onceAsync(a, 2)
+  t.is(a.next, 3)
+  await utils.onceAsync(a, 3)
+  t.is(a.next, 4)
+
+  a = new AssertOrder()
+  await t.throws(utils.onceAsync(a, 1), "Expecting 'once(0)', 'step(0)', 'some(0)', 'all(0)', 'multiple(0)', but received 'once(1)'")
+
+  a = new AssertOrder()
+  await utils.onceAsync(a, 0)
+  await t.throws(utils.onceAsync(a, 2), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'once(2)'")
+
+  a = new AssertOrder()
+  await utils.onceAsync(a, 0)
+  await t.throws(utils.onceAsync(a, 0), "Expecting 'once(1)', 'step(1)', 'some(1)', 'all(1)', 'multiple(1)', but received 'once(0)'")
 })
 
 test('step()', t => {

--- a/src/assertOrder.spec.ts
+++ b/src/assertOrder.spec.ts
@@ -3,7 +3,7 @@ import utils from './testUtils'
 import AssertOrder from './index'
 
 
-test('different starting index', t => {
+test('different starting index', _t => {
   let a = new AssertOrder(0, 1)
   a.once(1)
   a.once(2)

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,50 +1,34 @@
-export default {
-  runAsync: (fn) => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        try {
-          resolve(fn())
-        }
-        catch (err) {
-          reject(err)
-        }
-      }, 1)
-    })
-  },
-  runSequentialAsync: (...fns) => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        try {
-          let i = 0
-          for (; i < fns.length - 1; i++) {
-            fns[i]()
-          }
-          resolve(fns[i]())
-        }
-        catch (err) {
-          reject(err)
-        }
-      }, 1)
-    })
-  },
-  runParallelAsync: (...fns) => {
-    const promises: Promise<any>[] = []
-    for (let i = 0; i < fns.length; i++) {
-      promises.push(new Promise((resolve, reject) => {
-        setTimeout(() => {
-          try {
-            let i = 0
-            for (; i < fns.length - 1; i++) {
-              fns[i]()
-            }
-            resolve(fns[i]())
-          }
-          catch (err) {
-            reject(err)
-          }
-        }, 1)
-      }))
-    }
-    return Promise.all(promises)
-  }
+export function runAsync(fn) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        resolve(fn())
+      }
+      catch (err) {
+        reject(err)
+      }
+    }, 1)
+  })
 }
+
+export function runSequentialAsync(...fns) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        let i = 0
+        for (; i < fns.length - 1; i++) {
+          fns[i]()
+        }
+        resolve(fns[i]())
+      }
+      catch (err) {
+        reject(err)
+      }
+    }, 1)
+  })
+}
+
+export function runParallelAsync(...fns) {
+  return Promise.all(fns.map(fn => runAsync(fn)))
+}
+

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,14 +1,50 @@
 export default {
-  onceAsync: (assert, arg) => {
+  runAsync: (fn) => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         try {
-          resolve(assert.once(arg))
+          resolve(fn())
         }
         catch (err) {
           reject(err)
         }
       }, 1)
     })
+  },
+  runSequentialAsync: (...fns) => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        try {
+          let i = 0
+          for (; i < fns.length - 1; i++) {
+            fns[i]()
+          }
+          resolve(fns[i]())
+        }
+        catch (err) {
+          reject(err)
+        }
+      }, 1)
+    })
+  },
+  runParallelAsync: (...fns) => {
+    const promises: Promise<any>[] = []
+    for (let i = 0; i < fns.length; i++) {
+      promises.push(new Promise((resolve, reject) => {
+        setTimeout(() => {
+          try {
+            let i = 0
+            for (; i < fns.length - 1; i++) {
+              fns[i]()
+            }
+            resolve(fns[i]())
+          }
+          catch (err) {
+            reject(err)
+          }
+        }, 1)
+      }))
+    }
+    return Promise.all(promises)
   }
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,0 +1,14 @@
+export default {
+  onceAsync: (assert, arg) => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        try {
+          resolve(assert.once(arg))
+        }
+        catch (err) {
+          reject(err)
+        }
+      }, 1)
+    })
+  }
+}


### PR DESCRIPTION
Hi Homa,

Here's a try to the issue [#10](https://github.com/unional/assert-order/issues/10).
I only did it for testing 'once' asynchronously now, and would like to hear your feedback before apply it to all other methods. Please feel free to give any feedback.

Thanks,
Chen