### PR TITLE
Added AssertError class for handling assertion errors

### DIFF
--- a/src/assertError.spec.ts
+++ b/src/assertError.spec.ts
@@ -1,19 +1,19 @@
-﻿import test from 'ava'
+import test from 'ava'
 import AssertError from './assertError'
 
 test('test error format based on input', _t => {
   let reverseAlias = {
-    alias1: ['method1', 'method2'],
-    alias2: [], // new method
-    alias3: ['method3']
+    once: ['method1', 'method2'],
+    some: [], // new method
+    all: ['method3']
   }
 
   let possibleMoves = {
-    alias1: [2],
-    alias2: [2],
-    alias3: [1, 2]
+    once: [2],
+    some: [2],
+    all: [1, 2]
   }
 
   let error = new AssertError(possibleMoves, reverseAlias, 'calledMethod', 3, 4, 5);
-  _t.is(error.message, 'Expecting \'alias1(2)\', \'method1(2)\', \'method2(2)\', \'alias2(2)\', \'alias3(1|2)\', \'method3(1|2)\', but received \'calledMethod(3,4,5)\'')
+  _t.is(error.message, "Expecting 'once(2)', 'method1(2)', 'method2(2)', 'some(2)', 'all(1|2)', 'method3(1|2)', but received 'calledMethod(3,4,5)'")
 })

--- a/src/assertError.spec.ts
+++ b/src/assertError.spec.ts
@@ -1,0 +1,20 @@
+﻿import test from 'ava'
+import AssertError from './assertError'
+
+test('test error format based on input', _t => {
+  let reverseAlias = {
+    alias1: ['method1', 'method2'],
+    alias2: [], // new method
+    alias3: ['method3']
+  }
+
+  let possibleMoves = {
+    alias1: [2],
+    alias2: [2],
+    alias3: [1, 2]
+  }
+
+  let error = new AssertError(possibleMoves, reverseAlias, 'calledMethod', 3, 4, 5);
+  console.log(error.message);
+  _t.is(error.message, 'Expecting \'alias1(2)\', \'method1(2)\', \'method2(2)\', \'alias2(2)\', \'alias3(1|2)\', \'method3(1|2)\', but received \'calledMethod(3,4,5)\'')
+})

--- a/src/assertError.spec.ts
+++ b/src/assertError.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import AssertError from './assertError'
+import { AssertError } from './assertError'
 
 test('test error format based on input', _t => {
   let reverseAlias = {

--- a/src/assertError.spec.ts
+++ b/src/assertError.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { AssertError } from './assertError'
 
-test('test error format based on input', _t => {
+test('test error format based on input', t => {
   let reverseAlias = {
     once: ['method1', 'method2'],
     some: [], // new method
@@ -15,5 +15,5 @@ test('test error format based on input', _t => {
   }
 
   let error = new AssertError(possibleMoves, reverseAlias, 'calledMethod', 3, 4, 5);
-  _t.is(error.message, "Expecting 'once(2)', 'method1(2)', 'method2(2)', 'some(2)', 'all(1|2)', 'method3(1|2)', but received 'calledMethod(3,4,5)'")
+  t.is(error.message, "Expecting 'once(2)', 'method1(2)', 'method2(2)', 'some(2)', 'all(1|2)', 'method3(1|2)', but received 'calledMethod(3,4,5)'")
 })

--- a/src/assertError.spec.ts
+++ b/src/assertError.spec.ts
@@ -15,6 +15,5 @@ test('test error format based on input', _t => {
   }
 
   let error = new AssertError(possibleMoves, reverseAlias, 'calledMethod', 3, 4, 5);
-  console.log(error.message);
   _t.is(error.message, 'Expecting \'alias1(2)\', \'method1(2)\', \'method2(2)\', \'alias2(2)\', \'alias3(1|2)\', \'method3(1|2)\', but received \'calledMethod(3,4,5)\'')
 })

--- a/src/assertError.ts
+++ b/src/assertError.ts
@@ -1,4 +1,4 @@
-﻿import Steps from './assertOrder'
+﻿import { Steps } from './assertOrder'
 
 export default class AssertError extends Error {
   constructor(possibleMoves: Steps, reverseAlias: object, calledFn: string, ...calledSteps: number[]) {

--- a/src/assertError.ts
+++ b/src/assertError.ts
@@ -1,6 +1,6 @@
 import { Steps } from './assertOrder'
 
-export default class AssertError extends Error {
+export class AssertError extends Error {
   constructor(possibleMoves: Steps, reverseAlias: object, calledFn: string, ...calledSteps: number[]) {
     const should: string[] = []
     for (let key in possibleMoves) {

--- a/src/assertError.ts
+++ b/src/assertError.ts
@@ -1,0 +1,14 @@
+﻿import Steps from './assertOrder'
+
+export default class AssertError extends Error {
+  constructor(possibleMoves: Steps, reverseAlias: object, calledFn: string, ...calledSteps: number[]) {
+    const should: string[] = []
+    for (let key in possibleMoves) {
+      should.push(...[key].concat(reverseAlias[key]).map(name =>
+        `'${name}(${possibleMoves[key].join('|')})'`
+      ))
+    }
+
+    super(`Expecting ${should.join(', ')}, but received '${calledFn}(${calledSteps.join(',')})'`)
+  }
+}

--- a/src/assertError.ts
+++ b/src/assertError.ts
@@ -1,4 +1,4 @@
-﻿import { Steps } from './assertOrder'
+import { Steps } from './assertOrder'
 
 export default class AssertError extends Error {
   constructor(possibleMoves: Steps, reverseAlias: object, calledFn: string, ...calledSteps: number[]) {

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,4 +1,4 @@
-﻿import AssertError from './assertError'
+import AssertError from './assertError'
 
 export interface Steps {
   once?: number[]

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,4 +1,4 @@
-import AssertError from './assertError'
+import { AssertError } from './assertError'
 
 export interface Steps {
   once?: number[]

--- a/src/assertOrder.ts
+++ b/src/assertOrder.ts
@@ -1,3 +1,5 @@
+﻿import AssertError from './assertError'
+
 export interface Steps {
   once?: number[]
   some?: number[]
@@ -70,7 +72,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('step', step))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'step', step)
     }
   }
 
@@ -84,7 +86,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('once', step))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'once', step)
     }
   }
 
@@ -98,7 +100,7 @@ export class AssertOrder {
       return this.nextStep++
     }
     else {
-      throw new Error(this.getErrorMessage('any', ...anySteps))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'any', ...anySteps)
     }
   }
 
@@ -121,7 +123,7 @@ export class AssertOrder {
       return ++this.miniSteps
     }
     else {
-      throw new Error(this.getErrorMessage('some', step))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'some', step)
     }
   }
 
@@ -136,7 +138,7 @@ export class AssertOrder {
       return this.moveAllState(step, plan)
     }
     else {
-      throw new Error(this.getErrorMessage('all', step))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'all', step)
     }
   }
 
@@ -151,7 +153,7 @@ export class AssertOrder {
       return this.moveAllState(step, plan)
     }
     else {
-      throw new Error(this.getErrorMessage('multiple', step))
+      throw new AssertError(this.possibleMoves, AssertOrder.reverseAlias, 'multiple', step)
     }
   }
 
@@ -194,16 +196,5 @@ export class AssertOrder {
     all: [this.nextStep + 1]
   }) {
     this.possibleMoves = nextMoves
-  }
-
-  private getErrorMessage(calledFn: string, ...calledSteps: number[]) {
-    const should: string[] = []
-    for (let key in this.possibleMoves) {
-      should.push(...([key, ...AssertOrder.reverseAlias[key]].map(name =>
-        `'${name}(${this.possibleMoves[key].join('|')})'`
-      )))
-    }
-
-    return `Expecting ${should.join(', ')}, but received '${calledFn}(${calledSteps.join(',')})'`
   }
 }


### PR DESCRIPTION
AssertError extends the Error class and takes in the state of the
assertOrder instance to create a standard error message. The unit test
ensures that the error message is being generated in the right format.